### PR TITLE
Bandwidth throttle support

### DIFF
--- a/mitm_proxy_helpers/proxy.py
+++ b/mitm_proxy_helpers/proxy.py
@@ -403,7 +403,7 @@ class Proxy(ProxyLogger):
         returns: True on success
         """
         if not self.remote:
-            error_msg = 'Cannot throttle in non local mode'
+            error_msg = 'Cannot throttle in non remote mode'
             self.log_output(error_msg)
             return False, error_msg
         if os.getenv('server_os_type', 'Linux') not in ['Linux']:

--- a/mitm_proxy_helpers/server_scripts/proxy_launcher.py
+++ b/mitm_proxy_helpers/server_scripts/proxy_launcher.py
@@ -41,9 +41,9 @@ class MitmProxy(ProxyLogger):
                 ignore_str += ip_addresses[0].replace(r'.', r'\.') + r":80"
             else:
                 ip_addresses = list(set(ip_addresses))
-                for ip in ip_addresses[:-1]:
+                for ip_addr in ip_addresses[:-1]:
                     # All but the last IP address entry
-                    ignore_str += ip.replace(r'.', r'\.') + r":80|"
+                    ignore_str += ip_addr.replace(r'.', r'\.') + r":80|"
                 else:
                     # Last IP address entry
                     ignore_str += ip_addresses[-1].replace(r'.', r'\.') + r":80"


### PR DESCRIPTION
 - add bandwidth throttle helper
 - add new mitm env variable 'mitm_proxy_mode' to be set to either transparent or regular, defaulting to transparent, since transparent is required for router iptables with remote server (eg: stb-tester), regular is required for direct connection to remote server (eg: selenium_bdd)
- set the default state for start_proxy() to be 'no_script' which starts mitmdump without any script loaded, whereas before it was with har_logging


