### PR TITLE
Fixing Paramiko Dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 pylint-runner = "==0.5.4"
 pylint = "==2.4.4"
-paramiko = "*"
+paramiko = "==2.4.2"
 selenium = "*"
 
 [dev-packages]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        "paramiko",
+        "paramiko>=2.4.1,<2.4.3",
         "selenium"
     ],
     keywords=['MITM', 'proxy', 'helpers'],


### PR DESCRIPTION
- Fixing paramiko version in line with cryptography library >2.1.4,<=2.4 to prevent breakage in compatibility with mitmproxy which cannot use latest cryptography libraries